### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing to MeshtasticForeman
+
+Thanks for contributing.
+
+## Before you start
+
+- Search existing issues and pull requests before opening a new one.
+- For bugs, include clear reproduction steps and environment details.
+- For larger features or behavior changes, open an issue first so scope is clear before implementation starts.
+
+## Local setup
+
+```sh
+cp .env.example .env
+pnpm install
+./start-both.sh
+```
+
+On Windows, use `start-both.ps1`.
+
+Useful commands:
+
+```sh
+pnpm build
+pnpm test
+pnpm --filter @foreman/web build
+pnpm --filter @foreman/daemon build
+```
+
+## Project conventions
+
+- User-defined variables belong in the root `.env` file.
+- Keep pull requests focused. Avoid bundling unrelated fixes together.
+- Do not revert unrelated user changes in a dirty worktree.
+- Update docs when behavior, setup, or configuration changes.
+
+## Pull requests
+
+Please include:
+
+- What changed
+- Why it changed
+- How you tested it
+- Screenshots for UI changes when relevant
+
+Small, reviewable PRs are preferred over large batches of unrelated work.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,78 @@
+name: Bug report
+description: Report a reproducible problem in MeshtasticForeman
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. Please include enough detail for someone else to reproduce it.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What went wrong?
+      placeholder: Short description of the bug
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Exact steps, starting from a known state
+      placeholder: |
+        1. Start the app with ...
+        2. Open ...
+        3. Click ...
+        4. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Paste relevant logs or attach screenshots
+      render: shell
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      placeholder: e.g. 0.7.6, main, commit SHA
+
+  - type: input
+    id: os
+    attributes:
+      label: OS
+      placeholder: e.g. Windows 11, macOS 15, Ubuntu 24.04
+
+  - type: input
+    id: device
+    attributes:
+      label: Meshtastic device / transport
+      placeholder: e.g. T-Echo over USB serial, COM7, /dev/ttyUSB0
+
+  - type: textarea
+    id: env
+    attributes:
+      label: Relevant configuration
+      description: Include any relevant `.env` settings, redacting secrets
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Setup and configuration docs
+    url: https://github.com/mrdatawolf/MeshtasticForeman/blob/main/docs/SETUP.md
+    about: Check setup, ports, environment variables, and installer details
+  - name: Architecture and API docs
+    url: https://github.com/mrdatawolf/MeshtasticForeman/blob/main/README.md
+    about: Review project structure and linked documentation before filing an issue

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,33 @@
+name: Feature request
+description: Suggest an improvement or new capability
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What are you trying to do that the current app does not support well?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the change you want
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Screenshots, workflows, constraints, or related links

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Summary
+
+- What changed?
+- Why did it change?
+
+## Testing
+
+- [ ] `pnpm build`
+- [ ] `pnpm test` if applicable
+- [ ] Manual verification completed
+
+## Screenshots
+
+- [ ] UI screenshots attached if this changes visible behavior
+
+## Notes
+
+- Any migration, config, compatibility, or follow-up notes for reviewers

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Pre-built installers for Windows and Linux are on the [Releases](../../releases)
 
 Patches, bug reports, and feature suggestions are welcome. Fork the repo, make your change on a branch, and open a pull request with a clear description. Not sure where to start? Open an issue first — no PR required to start a conversation.
 
+See [CONTRIBUTING.md](.github/CONTRIBUTING.md) for setup, workflow, and PR expectations.
+
 ## Thanks
 
 None of this would exist without the [Meshtastic](https://meshtastic.org) team and community — they built the firmware, protocol, and client libraries this project builds on top of.


### PR DESCRIPTION
## Summary
- add standard GitHub community health files for contributions
- add structured bug report and feature request issue templates
- add an issue template config and pull request template
- link the new contribution guide from the README

## Testing
- reviewed generated GitHub community files locally

## Screenshots
- not applicable