### PR TITLE
Add conversation deletion in messages

### DIFF
--- a/packages/daemon/src/device/device-manager.ts
+++ b/packages/daemon/src/device/device-manager.ts
@@ -436,6 +436,15 @@ export class DeviceManager extends EventEmitter {
     }));
   }
 
+  async deleteConversation(deviceId: string, nodeId: number): Promise<void> {
+    await this.db.query(
+      `DELETE FROM messages
+       WHERE device_id = $1
+         AND (to_node_id = $2 OR from_node_id = $2)`,
+      [deviceId, nodeId]
+    );
+  }
+
   // ---------------------------------------------------------------------------
   // Private helpers
   // ---------------------------------------------------------------------------

--- a/packages/daemon/src/routes/devices.ts
+++ b/packages/daemon/src/routes/devices.ts
@@ -81,6 +81,16 @@ export async function registerDeviceRoutes(
     return reply.status(204).send();
   });
 
+  app.delete("/api/devices/:id/messages/:nodeId", async (req, reply) => {
+    const { id, nodeId: rawNodeId } = req.params as { id: string; nodeId: string };
+    const nodeId = Number(rawNodeId);
+    if (!Number.isInteger(nodeId) || nodeId < 0) {
+      return reply.status(400).send({ error: "Invalid nodeId" });
+    }
+    await deviceManager.deleteConversation(id, nodeId);
+    return reply.status(204).send();
+  });
+
   // ---------------------------------------------------------------------------
   // Node overrides — local fallback names/positions, never written to the mesh
   // ---------------------------------------------------------------------------

--- a/packages/web/src/pages/MessagesPage.tsx
+++ b/packages/web/src/pages/MessagesPage.tsx
@@ -6,6 +6,7 @@ import {
   useConversation,
   loadConversation,
   addOptimisticMessage,
+  clearConversation,
   BROADCAST,
 } from "../store/messages.js";
 
@@ -58,9 +59,10 @@ interface ThreadProps {
   nodes: NodeInfo[];
   mqttNodes: MqttNode[];
   deviceId: string;
+  onDeleteConversation: (nodeId: number) => void;
 }
 
-function ThreadView({ nodeId, nodes, mqttNodes, deviceId }: ThreadProps) {
+function ThreadView({ nodeId, nodes, mqttNodes, deviceId, onDeleteConversation }: ThreadProps) {
   const messages = useConversation(nodeId);
   const [msgText, setMsgText] = useState("");
   const [channel, setChannel] = useState(0);
@@ -110,10 +112,19 @@ function ThreadView({ nodeId, nodes, mqttNodes, deviceId }: ThreadProps) {
   return (
     <div style={styles.thread}>
       <div style={styles.threadHeader}>
-        <span style={styles.threadName}>{name}</span>
-        {nodeId !== BROADCAST && (
-          <span style={styles.threadHex}>{nodeHex(nodeId)}</span>
-        )}
+        <div style={{ display: "flex", alignItems: "baseline", gap: "0.75rem" }}>
+          <span style={styles.threadName}>{name}</span>
+          {nodeId !== BROADCAST && (
+            <span style={styles.threadHex}>{nodeHex(nodeId)}</span>
+          )}
+        </div>
+        <button
+          style={styles.deleteBtn}
+          onClick={() => onDeleteConversation(nodeId)}
+          title="Delete this conversation"
+        >
+          Delete
+        </button>
       </div>
 
       <div style={styles.messageList}>
@@ -200,6 +211,20 @@ export function MessagesPage({ devices, nodes, mqttNodes, initialNodeId, onIniti
   const [pickerOpen, setPickerOpen] = useState(false);
   const pickerRef = useRef<HTMLDivElement>(null);
   const deviceId = devices.find((d) => d.status === "connected")?.id ?? null;
+
+  const deleteConversation = useCallback(async (nodeId: number) => {
+    if (!deviceId) return;
+    const name = nodeName(nodeId, nodes, mqttNodes);
+    const ok = window.confirm(`Delete conversation with ${name}?`);
+    if (!ok) return;
+    await fetch(`/api/devices/${deviceId}/messages/${nodeId}`, { method: "DELETE" });
+    clearConversation(nodeId);
+    setSelectedNodeId((current) => {
+      if (current !== nodeId) return current;
+      const remaining = conversations.filter((c) => c.nodeId !== nodeId);
+      return remaining[0]?.nodeId ?? null;
+    });
+  }, [conversations, deviceId, mqttNodes, nodes]);
 
   // Honour external navigation (e.g. "✉ Msg" from Nodes page)
   useEffect(() => {
@@ -310,6 +335,7 @@ export function MessagesPage({ devices, nodes, mqttNodes, initialNodeId, onIniti
             nodes={nodes}
             mqttNodes={mqttNodes}
             deviceId={deviceId}
+            onDeleteConversation={deleteConversation}
           />
         ) : (
           <div style={styles.placeholder}>
@@ -489,7 +515,8 @@ const styles: Record<string, React.CSSProperties> = {
     borderBottom: "1px solid #1e293b",
     flexShrink: 0,
     display: "flex",
-    alignItems: "baseline",
+    alignItems: "center",
+    justifyContent: "space-between",
     gap: "0.75rem",
   },
   threadName: {
@@ -501,6 +528,17 @@ const styles: Record<string, React.CSSProperties> = {
     color: "#475569",
     fontSize: "0.78rem",
     fontFamily: "monospace",
+  },
+  deleteBtn: {
+    background: "#450a0a",
+    border: "1px solid #991b1b",
+    color: "#f87171",
+    padding: "0.2rem 0.55rem",
+    borderRadius: "0.3rem",
+    cursor: "pointer",
+    fontFamily: "monospace",
+    fontSize: "0.72rem",
+    flexShrink: 0,
   },
   messageList: {
     flex: 1,

--- a/packages/web/src/store/messages.ts
+++ b/packages/web/src/store/messages.ts
@@ -22,13 +22,26 @@ function otherNodeId(msg: Message): number {
   return msg.role === "sent" ? msg.toNodeId : msg.fromNodeId;
 }
 
+function messageSignature(msg: Message): string {
+  return [
+    msg.packetId,
+    msg.fromNodeId,
+    msg.toNodeId,
+    msg.channelIndex,
+    msg.role,
+    msg.text ?? "",
+    msg.rxTime,
+  ].join(":");
+}
+
 function addOrUpdate(msg: Message) {
   const key = otherNodeId(msg);
   const existing = conversations.get(key) ?? [];
-  const idx = existing.findIndex((m) => m.id === msg.id);
+  const sig = messageSignature(msg);
+  const idx = existing.findIndex((m) => m.id === msg.id || messageSignature(m) === sig);
   if (idx >= 0) {
     const next = [...existing];
-    next[idx] = msg;
+    next[idx] = { ...next[idx], ...msg };
     conversations.set(key, next);
   } else {
     conversations.set(key, [...existing, msg]);
@@ -85,7 +98,11 @@ export function initMessageStore() {
       for (const [key, newMsgs] of grouped) {
         const existing = conversations.get(key) ?? [];
         const optimistic = existing.filter((m) => m.id.startsWith("local-"));
-        const merged = [...newMsgs, ...optimistic].sort(
+        const deduped = new Map<string, Message>();
+        for (const msg of [...newMsgs, ...optimistic]) {
+          deduped.set(messageSignature(msg), msg);
+        }
+        const merged = [...deduped.values()].sort(
           (a, b) => new Date(a.rxTime).getTime() - new Date(b.rxTime).getTime()
         );
         conversations.set(key, merged);
@@ -117,6 +134,11 @@ export function addOptimisticMessage(msg: Message) {
   const key = otherNodeId(msg);
   const existing = conversations.get(key) ?? [];
   conversations.set(key, [...existing, msg]);
+  notify();
+}
+
+export function clearConversation(nodeId: number) {
+  conversations.delete(nodeId);
   notify();
 }
 


### PR DESCRIPTION
## Summary
- add a delete action for the active conversation in the Messages view
- remove deleted conversations from the local sidebar immediately
- improve client-side message deduping so repeated live/history copies collapse more reliably

## Testing
- verified this change set in the main workspace before splitting into a clean branch

## Screenshots
- not attached