### PR TITLE
Fix repeated message history requests from node detail panel

### DIFF
--- a/packages/web/src/pages/NodeDetailPanel.tsx
+++ b/packages/web/src/pages/NodeDetailPanel.tsx
@@ -74,7 +74,7 @@ export function NodeDetailPanel({ nodeId, mesh, mqtt, devices, onClose, onMessag
       }
     });
     return () => { off(); };
-  }, [deviceId, nodeId, onClose]);
+  }, [deviceId, nodeId]);
 
   // Auto-scroll messages
   useEffect(() => {


### PR DESCRIPTION
## Summary
- stop the node detail panel from re-requesting message history on unrelated rerenders
- narrow the history-loading effect dependencies to the selected device/node pair

## Testing
- pnpm --filter @foreman/web build

Closes #44